### PR TITLE
Add lower bound for base

### DIFF
--- a/compact-word-vectors.cabal
+++ b/compact-word-vectors.cabal
@@ -31,7 +31,7 @@ source-repository head
 
 Library
 
-  Build-Depends:       base >= 4 && < 5, primitive >= 0.7
+  Build-Depends:       base >= 4.8 && < 5, primitive >= 0.7
 
   Exposed-Modules:     Data.Vector.Compact.WordVec
                        Data.Vector.Compact.IntVec


### PR DESCRIPTION
For earlier versions build fails with
```
[1 of 3] Compiling Data.Vector.Compact.Blob
src/Data/Vector/Compact/Blob.hs:518:7: Not in scope: ‘<$>’
src/Data/Vector/Compact/Blob.hs:532:7: Not in scope: ‘<$>’
```

As a Hackage trustee I made appropriate revisions:
https://hackage.haskell.org/package/compact-word-vectors-0.2.0.1/revisions/
https://hackage.haskell.org/package/compact-word-vectors-0.2.0.2/revisions/